### PR TITLE
Compatibilité Mantis 2.x + améliorations

### DIFF
--- a/AutoChangeStatus/AutoChangeStatus.php
+++ b/AutoChangeStatus/AutoChangeStatus.php
@@ -26,9 +26,9 @@ class AutoChangeStatusPlugin extends MantisPlugin
         $this->name =  plugin_lang_get('plugin_title');
         $this->description = plugin_lang_get('plugin_description');
         $this->page = 'config.php';
-        $this->version = '0.1.4';
+        $this->version = '2.0.0';
         $this->requires = array(
-            'MantisCore' => '1.3.0',
+            'MantisCore' => '2.0.0',
         );
         $this->author = 'Hennes Hervé';
         $this->url = 'http://www.h-hennes.fr';
@@ -49,7 +49,7 @@ class AutoChangeStatusPlugin extends MantisPlugin
      */
     public function install(){
 
-        return db_query("CREATE TABLE IF NOT EXISTS `mantis_autochange_status` (
+        return db_query("CREATE TABLE IF NOT EXISTS ".db_get_table('plugin_autochangestatus')." (
                         `changestatus_id` int(11) NOT NULL AUTO_INCREMENT,
                         `project_id` int(11) NOT NULL,
                         `from_status` int(3) NOT NULL,
@@ -57,10 +57,11 @@ class AutoChangeStatusPlugin extends MantisPlugin
                         `status_days` int(3) NOT NULL,
                         `reminder` tinyint(1) NOT NULL,
                         `reminder_message` varchar(255) NOT NULL,
+                        `reminder_message_private` tinyint(1) NOT NULL,
                         `reminder_days` int(11) NOT NULL,
                         `active` tinyint(1) NOT NULL,
                         PRIMARY KEY (`changestatus_id`)
-                      ) ENGINE=InnoDB DEFAULT CHARSET=latin1 AUTO_INCREMENT=1 ;");
+                      ) ENGINE=InnoDB DEFAULT CHARSET=utf8;");
 
     }
 
@@ -68,7 +69,7 @@ class AutoChangeStatusPlugin extends MantisPlugin
      * Desinstallation du plugin
      */
     public function uninstall(){
-        return db_query('DROP TABLE '.db_get_table('autochange_status'));
+        return db_query('DROP TABLE '.db_get_table('plugin_autochangestatus'));
     }
 
 }

--- a/AutoChangeStatus/AutoChangeStatus.php
+++ b/AutoChangeStatus/AutoChangeStatus.php
@@ -49,14 +49,14 @@ class AutoChangeStatusPlugin extends MantisPlugin
      */
     public function install(){
 
-        return db_query("CREATE TABLE IF NOT EXISTS ".db_get_table('plugin_autochangestatus')." (
+        return db_query("CREATE TABLE IF NOT EXISTS {plugin_autochangestatus} (
                         `changestatus_id` int(11) NOT NULL AUTO_INCREMENT,
                         `project_id` int(11) NOT NULL,
                         `from_status` int(3) NOT NULL,
                         `to_status` int(3) NOT NULL,
                         `status_days` int(3) NOT NULL,
                         `reminder` tinyint(1) NOT NULL,
-                        `reminder_message` varchar(255) NOT NULL,
+                        `reminder_message` text,
                         `reminder_message_private` tinyint(1) NOT NULL,
                         `reminder_days` int(11) NOT NULL,
                         `active` tinyint(1) NOT NULL,
@@ -69,7 +69,7 @@ class AutoChangeStatusPlugin extends MantisPlugin
      * Desinstallation du plugin
      */
     public function uninstall(){
-        return db_query('DROP TABLE '.db_get_table('plugin_autochangestatus'));
+        return db_query("DROP TABLE {plugin_autochangestatus}");
     }
 
 }

--- a/AutoChangeStatus/AutoChangeStatus.php
+++ b/AutoChangeStatus/AutoChangeStatus.php
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 <?php
 # MantisBT - A PHP based bugtracking system
 # MantisBT is free software: you can redistribute it and/or modify

--- a/AutoChangeStatus/lang/strings_english.txt
+++ b/AutoChangeStatus/lang/strings_english.txt
@@ -15,9 +15,14 @@ $s_plugin_AutoChangeStatus_project = 'Project Name';
 $s_plugin_AutoChangeStatus_from_status = 'From Status';
 $s_plugin_AutoChangeStatus_to_status = 'To Status';
 $s_plugin_AutoChangeStatus_status_days = 'Number of days';
+$s_plugin_AutoChangeStatus_status_days_description = 'Number of days before automatic status modification, if no changes.';
 $s_plugin_AutoChangeStatus_reminder = 'Reminder';
 $s_plugin_AutoChangeStatus_reminder_message = 'Reminder Message';
+$s_plugin_AutoChangeStatus_reminder_message_description = 'Available tokens:';
+$s_plugin_AutoChangeStatus_reminder_message_private = 'Reminder note visibility';
+$s_plugin_AutoChangeStatus_reminder_message_private_short = 'Private note';
 $s_plugin_AutoChangeStatus_reminder_days = 'Number of days';
+$s_plugin_AutoChangeStatus_reminder_days_description = 'Number of days before adding of a note, if no changes.';
 $s_plugin_AutoChangeStatus_active = 'Active';
 $s_plugin_AutoChangeStatus_edit = 'Edit';
 $s_plugin_AutoChangeStatus_no_update_changes_created = 'No change updates created';
@@ -28,7 +33,13 @@ $s_plugin_AutoChangeStatus_create_new_change_description = ' Add new status chan
 $s_plugin_AutoChangeStatus_all_projects = 'All projects';
 $s_plugin_AutoChangeStatus_yes = 'Yes';
 $s_plugin_AutoChangeStatus_no = 'No';
-$s_plugin_AutoChangeStatus_create_change = 'Create';
+$s_plugin_AutoChangeStatus_create = 'Create';
+$s_plugin_AutoChangeStatus_change = 'Save modifications';
+$s_plugin_AutoChangeStatus_delete = 'Delete';
 $s_plugin_AutoChangeStatus_before_change_status_message = "Hello,\n\nThis bug is in status '%s' since %d days.\n\nWithout any return from you its status will change to '%s' in %d days \n\n\nautomatic message";
 $s_plugin_AutoChangeStatus_change_status_message = "Automatic status change \no customer return since %d days";
- 
+$s_plugin_AutoChangeStatus_back = "Back";
+
+#Delete a change status rule
+$s_plugin_AutoChangeStatus_ensure_delete = 'Do you really want to delete this automatic status change rule?';
+$s_plugin_AutoChangeStatus_delete_changestatus = 'Delete automatic status change rule';

--- a/AutoChangeStatus/lang/strings_french.txt
+++ b/AutoChangeStatus/lang/strings_french.txt
@@ -18,6 +18,7 @@ $s_plugin_AutoChangeStatus_status_days = 'Nombre de jours avant changement';
 $s_plugin_AutoChangeStatus_status_days_description = 'Nombre de jours avant modification automatique du statut si aucune modification n\'est apportée.';
 $s_plugin_AutoChangeStatus_reminder = 'Rappel';
 $s_plugin_AutoChangeStatus_reminder_message = 'Note de rappel';
+$s_plugin_AutoChangeStatus_reminder_message_description = 'Les macros disponibles sont les suivantes :';
 $s_plugin_AutoChangeStatus_reminder_message_private = 'Visibilité de la note de rappel';
 $s_plugin_AutoChangeStatus_reminder_message_private_short = 'Note privée';
 $s_plugin_AutoChangeStatus_reminder_days = 'Nombre de jours avant rappel';
@@ -36,7 +37,7 @@ $s_plugin_AutoChangeStatus_create = 'Créer';
 $s_plugin_AutoChangeStatus_change = 'Enregistrer les modifications';
 $s_plugin_AutoChangeStatus_delete = 'Supprimer';
 $s_plugin_AutoChangeStatus_before_change_status_message = "Bonjour,\n\nCe ticket est en statut '%s' depuis %d jours.\n\nSans ajout de note de votre part, son statut sera automatiquement changé en '%s' dans %d jours \n\n\nmessage automatique.";
-$s_plugin_AutoChangeStatus_change_status_message = "Changement automatique du statut du ticket \nPas de retour depuis %d jours";
+$s_plugin_AutoChangeStatus_change_status_message = "Changement automatique du statut du ticket en '%s'.\nPas de retour depuis %d jours";
 $s_plugin_AutoChangeStatus_back = "Retour";
 
 #Delete a change status rule

--- a/AutoChangeStatus/lang/strings_french.txt
+++ b/AutoChangeStatus/lang/strings_french.txt
@@ -6,20 +6,24 @@ $s_plugin_AutoChangeStatus_plugin_description = 'Change automatiquement les stat
 #Plugin configuration
 $s_plugin_AutoChangeStatus_title= 'Configurer le plugin AutoChangeStatus';
 $s_plugin_AutoChangeStatus_plugin_config_general_description = 'Configuration générale';
-$s_plugin_AutoChangeStatus_plugin_config_description = 'Sélectionner l\'utilisateur qui effectuera les changements de status, et l\'ajout des notes. Celui-ci devrait être un administrateur';
+$s_plugin_AutoChangeStatus_plugin_config_description = 'Sélectionner l\'utilisateur qui effectuera les changements de status, et l\'ajout des notes. Celui-ci devrait être un administrateur.';
 $s_plugin_AutoChangeStatus_change_status_user = 'Utilisateur';
-$s_plugin_AutoChangeStatus_select_user = 'Selectionner utilisateur';
+$s_plugin_AutoChangeStatus_select_user = 'Sélectionner utilisateur';
 $s_plugin_AutoChangeStatus_config_action_update = 'Mettre à jour';
 $s_plugin_AutoChangeStatus_plugin_changes_list = 'Liste des changements automatiques';
 $s_plugin_AutoChangeStatus_project = 'Projet';
 $s_plugin_AutoChangeStatus_from_status = 'Statut initial';
 $s_plugin_AutoChangeStatus_to_status = 'Statut final';
-$s_plugin_AutoChangeStatus_status_days = 'Nombre de jours';
+$s_plugin_AutoChangeStatus_status_days = 'Nombre de jours avant changement';
+$s_plugin_AutoChangeStatus_status_days_description = 'Nombre de jours avant modification automatique du statut si aucune modification n\'est apportée.';
 $s_plugin_AutoChangeStatus_reminder = 'Rappel';
-$s_plugin_AutoChangeStatus_reminder_message = 'Message de rappel';
-$s_plugin_AutoChangeStatus_reminder_days = 'Nombre de jours';
+$s_plugin_AutoChangeStatus_reminder_message = 'Note de rappel';
+$s_plugin_AutoChangeStatus_reminder_message_private = 'Visibilité de la note de rappel';
+$s_plugin_AutoChangeStatus_reminder_message_private_short = 'Note privée';
+$s_plugin_AutoChangeStatus_reminder_days = 'Nombre de jours avant rappel';
+$s_plugin_AutoChangeStatus_reminder_days_description = 'Nombre de jours avant ajout d\'une note si aucune modification n\'est apportée.';
 $s_plugin_AutoChangeStatus_active = 'Actif';
-$s_plugin_AutoChangeStatus_edit = 'Editer';
+$s_plugin_AutoChangeStatus_edit = 'Modifier';
 $s_plugin_AutoChangeStatus_no_update_changes_created = 'Pas de changements automatiques créés';
 $s_plugin_AutoChangeStatus_create_new_status_update = 'Créer un nouveau changement';
 
@@ -28,6 +32,13 @@ $s_plugin_AutoChangeStatus_create_new_change_description = 'Ajouter une nouveau 
 $s_plugin_AutoChangeStatus_all_projects = 'Tous les projets';
 $s_plugin_AutoChangeStatus_yes = 'Oui';
 $s_plugin_AutoChangeStatus_no = 'Non';
-$s_plugin_AutoChangeStatus_create_change = 'Créer';
+$s_plugin_AutoChangeStatus_create = 'Créer';
+$s_plugin_AutoChangeStatus_change = 'Enregistrer les modifications';
+$s_plugin_AutoChangeStatus_delete = 'Supprimer';
 $s_plugin_AutoChangeStatus_before_change_status_message = "Bonjour,\n\nCe ticket est en statut '%s' depuis %d jours.\n\nSans ajout de note de votre part, son statut sera automatiquement changé en '%s' dans %d jours \n\n\nmessage automatique.";
 $s_plugin_AutoChangeStatus_change_status_message = "Changement automatique du statut du ticket \nPas de retour depuis %d jours";
+$s_plugin_AutoChangeStatus_back = "Retour";
+
+#Delete a change status rule
+$s_plugin_AutoChangeStatus_ensure_delete = 'Voulez-vous vraiment supprimer ce changement automatique de statut ?';
+$s_plugin_AutoChangeStatus_delete_changestatus = 'Supprimer le changement automatique';

--- a/AutoChangeStatus/pages/changestatus.php
+++ b/AutoChangeStatus/pages/changestatus.php
@@ -97,89 +97,105 @@ $t_projects = project_cache_all();
                     <div class="widget-main no-padding">
                         <div class="table-responsive">
                             <table class="table table-bordered table-condensed table-striped">
-                                <tr>
-                                    <th class="category"><?php echo plugin_lang_get('project'); ?></th>
-                                    <td>
-                                        <select name="project_id" >
-                                            <option value="0"><?php echo plugin_lang_get('all_projects');?></option>
-                                            <?php foreach ($t_projects as $project): ?>
-                                            <option value="<?php echo $project['id']; ?>" <?php if ( $project['id'] == $change_datas['project_id'] ):?> selected="selected" <?php endif; ?>>
-                                                <?php echo $project['name']; ?>
-                                            </option>
-                                            <?php endforeach; ?>
-                                        </select>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th class="category"><?php echo plugin_lang_get('from_status'); ?></th>
-                                    <td>
-                                        <?php echo $function("from_status" , $change_datas['from_status']); ?>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th class="category"><?php echo plugin_lang_get('to_status'); ?></th>
-                                    <td>
-                                        <?php echo $function("to_status",$change_datas['to_status']); ?>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th class="category">
-                                        <?php echo plugin_lang_get('status_days'); ?>
-                                        <br>
-                                        <span class="small"><?php echo plugin_lang_get('status_days_description'); ?></span>
-                                    </th>
-                                    <td>
-                                        <input type="text" class="center" name="status_days" size="3" maxlength="3" value="<?php echo $change_datas['status_days'];?>"/>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th class="category"><?php echo plugin_lang_get('reminder'); ?></th>
-                                    <td>
-                                        <select name="reminder" >
-                                            <option value="1"<?php if ( 1 == $change_datas['reminder'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('yes'); ?></option>
-                                            <option value="0"<?php if ( 0 == $change_datas['reminder'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('no'); ?></option>
-                                        </select>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th class="category"><?php echo plugin_lang_get('reminder_message'); ?></th>
-                                    <td>
-                                        <textarea name="reminder_message" cols="60" rows="10"><?php echo isset($change_datas['reminder_message']) ? $change_datas['reminder_message']: plugin_lang_get('before_change_status_message');?></textarea>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th class="category"><?php echo plugin_lang_get('reminder_message_private'); ?></th>
-                                    <td>
-                                        <label for="reminder_message_private_off">
-                                            <input type="radio" class="ace" name="reminder_message_private" id="reminder_message_private_off" value="<?php echo OFF; ?>" <?php echo( ON != $change_datas['reminder_message_private'] ) ? 'checked="checked" ' : ''?>/>
-                                            <span class="lbl padding-6"><?php echo lang_get('public'); ?></span>
-                                        </label>
-                                        &nbsp;&nbsp;&nbsp;&nbsp;
-                                        <label for="reminder_message_private_on">
-                                            <input type="radio" class="ace" name="reminder_message_private" id="reminder_message_private_on" value="<?php echo ON; ?>" <?php echo( ON == $change_datas['reminder_message_private'] ) ? 'checked="checked" ' : ''?>/>
-                                            <span class="lbl padding-6"><?php echo lang_get('private'); ?></span>
-                                        </label>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th class="category">
-                                        <?php echo plugin_lang_get('reminder_days'); ?>
-                                        <br>
-                                        <span class="small"><?php echo plugin_lang_get('reminder_days_description'); ?></span>
-                                    </th>
-                                    <td>
-                                        <input type="text" class="center" name="reminder_days" size="3" maxlength="3" value="<?php echo $change_datas['reminder_days'];?>"/>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th class="category"><?php echo plugin_lang_get('active'); ?></th>
-                                    <td>
-                                        <select name="active" >
-                                            <option value="1" <?php if ( 1 == $change_datas['active'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('yes'); ?></option>
-                                            <option value="0" <?php if ( 0 == $change_datas['active'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('no'); ?></option>
-                                        </select>
-                                    </td>
-                                </tr>
+                                <tbody>
+                                    <tr>
+                                        <th class="category"><?php echo plugin_lang_get('project'); ?></th>
+                                        <td>
+                                            <select name="project_id" >
+                                                <option value="0"><?php echo plugin_lang_get('all_projects');?></option>
+                                                <?php foreach ($t_projects as $project): ?>
+                                                <option value="<?php echo $project['id']; ?>" <?php if ( $project['id'] == $change_datas['project_id'] ):?> selected="selected" <?php endif; ?>>
+                                                    <?php echo $project['name']; ?>
+                                                </option>
+                                                <?php endforeach; ?>
+                                            </select>
+                                        </td>
+                                    </tr>
+                                    <tr class="spacer"></tr>
+                                    <tr>
+                                        <th class="category"><?php echo plugin_lang_get('from_status'); ?></th>
+                                        <td>
+                                            <?php echo $function("from_status" , $change_datas['from_status']); ?>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="category"><?php echo plugin_lang_get('to_status'); ?></th>
+                                        <td>
+                                            <?php echo $function("to_status",$change_datas['to_status']); ?>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="category">
+                                            <?php echo plugin_lang_get('status_days'); ?>
+                                            <br>
+                                            <span class="small"><?php echo plugin_lang_get('status_days_description'); ?></span>
+                                        </th>
+                                        <td>
+                                            <input type="text" class="center" name="status_days" size="3" maxlength="3" value="<?php echo $change_datas['status_days'];?>"/>
+                                        </td>
+                                    </tr>
+                                    <tr class="spacer"></tr>
+                                    <tr>
+                                        <th class="category"><?php echo plugin_lang_get('reminder'); ?></th>
+                                        <td>
+                                            <select name="reminder" >
+                                                <option value="1"<?php if ( 1 == $change_datas['reminder'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('yes'); ?></option>
+                                                <option value="0"<?php if ( 0 == $change_datas['reminder'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('no'); ?></option>
+                                            </select>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="category">
+                                            <?php echo plugin_lang_get('reminder_message'); ?>
+                                            <div class="small">
+                                                Les macros disponibles sont les suivantes :
+                                                <ul>
+                                                    <li><code>{from_status}</code> <?php echo htmlentities(plugin_lang_get('from_status')) ?></li>
+                                                    <li><code>{to_status}</code> <?php echo htmlentities(plugin_lang_get('to_status')) ?></li>
+                                                    <li><code>{status_days}</code> <?php echo htmlentities(plugin_lang_get('status_days')) ?></li>
+                                                    <li><code>{reminder_days}</code> <?php echo htmlentities(plugin_lang_get('reminder_days')) ?></li>
+                                                </ul>
+                                            </div>
+                                        </th>
+                                        <td>
+                                            <textarea name="reminder_message" cols="60" rows="10"><?php echo isset($change_datas['reminder_message']) ? $change_datas['reminder_message']: plugin_lang_get('before_change_status_message');?></textarea>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="category"><?php echo plugin_lang_get('reminder_message_private'); ?></th>
+                                        <td>
+                                            <label for="reminder_message_private_off">
+                                                <input type="radio" class="ace" name="reminder_message_private" id="reminder_message_private_off" value="<?php echo OFF; ?>" <?php echo( ON != $change_datas['reminder_message_private'] ) ? 'checked="checked" ' : ''?>/>
+                                                <span class="lbl padding-6"><?php echo lang_get('public'); ?></span>
+                                            </label>
+                                            &nbsp;&nbsp;&nbsp;&nbsp;
+                                            <label for="reminder_message_private_on">
+                                                <input type="radio" class="ace" name="reminder_message_private" id="reminder_message_private_on" value="<?php echo ON; ?>" <?php echo( ON == $change_datas['reminder_message_private'] ) ? 'checked="checked" ' : ''?>/>
+                                                <span class="lbl padding-6"><?php echo lang_get('private'); ?></span>
+                                            </label>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="category">
+                                            <?php echo plugin_lang_get('reminder_days'); ?>
+                                            <br>
+                                            <span class="small"><?php echo plugin_lang_get('reminder_days_description'); ?></span>
+                                        </th>
+                                        <td>
+                                            <input type="text" class="center" name="reminder_days" size="3" maxlength="3" value="<?php echo $change_datas['reminder_days'];?>"/>
+                                        </td>
+                                    </tr>
+                                    <tr class="spacer"></tr>
+                                    <tr>
+                                        <th class="category"><?php echo plugin_lang_get('active'); ?></th>
+                                        <td>
+                                            <select name="active" >
+                                                <option value="1" <?php if ( 1 == $change_datas['active'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('yes'); ?></option>
+                                                <option value="0" <?php if ( 0 == $change_datas['active'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('no'); ?></option>
+                                            </select>
+                                        </td>
+                                    </tr>
+                                </tbody>
                             </table>
                         </div>
                     </div>

--- a/AutoChangeStatus/pages/changestatus.php
+++ b/AutoChangeStatus/pages/changestatus.php
@@ -25,7 +25,7 @@ access_ensure_global_level(config_get('manage_plugin_threshold'));
 if ( gpc_get('submitDelete',false)) {
     form_security_validate( 'plugin_AutoChangeStatus_changestatus_edit' );
     helper_ensure_confirmed( sprintf( plugin_lang_get( 'ensure_delete' ), $t_repo->name ), plugin_lang_get( 'delete_changestatus' ) );
-    $query = "DELETE FROM ".db_get_table('plugin_autochangestatus')." WHERE changestatus_id=".db_param();
+    $query = "DELETE FROM {plugin_autochangestatus} WHERE changestatus_id=".db_param();
     db_query_bound($query,array(gpc_get_int('changestatus_id')));
     print_successful_redirect( plugin_page( 'config', true ) );
     form_security_purge( 'plugin_AutoChangeStatus_changestatus_edit' );
@@ -39,7 +39,7 @@ print_manage_menu();
 #Gestion de la soumission du formulaire (Création )
 if ( gpc_get('submitCreate',false)) {
     form_security_validate( 'plugin_AutoChangeStatus_changestatus_edit' );
-    $query = "INSERT INTO ".db_get_table('plugin_autochangestatus')."
+    $query = "INSERT INTO {plugin_autochangestatus}
         (`project_id`,`from_status`,`to_status`,`status_days`,`reminder`,`reminder_message`,`reminder_message_private`,`reminder_days`,`active`)
         VALUES ( ".db_param().",".db_param().",".db_param().",".db_param().",".db_param().",".db_param().",".db_param().",".db_param().",".db_param().")";
 
@@ -56,7 +56,7 @@ if ( gpc_get('submitCreate',false)) {
 #Gestion de la soumission du formulaire (Mise à jour )
 if ( gpc_get('submitEdit',false)) {
     form_security_validate( 'plugin_AutoChangeStatus_changestatus_edit' );
-    $query = "UPDATE ".db_get_table('plugin_autochangestatus')." "
+    $query = "UPDATE {plugin_autochangestatus} "
         . "SET `project_id` =".db_param().",`from_status`=".db_param().",`to_status`=".db_param().",`status_days`=".db_param().",`reminder`=".db_param().",`reminder_message`=".db_param().",`reminder_message_private`=".db_param().",`reminder_days`=".db_param().",`active`=".db_param().""
         ." WHERE changestatus_id=".db_param();
 
@@ -71,7 +71,7 @@ if ( gpc_get('submitEdit',false)) {
 
 #Mise à jour récupération des données
 if ( $edit_id = gpc_get_int('changestatus_id' , false) ) {
-    $change_query = db_query("SELECT * FROM ".db_get_table('plugin_autochangestatus')." WHERE changestatus_id=".$edit_id);
+    $change_query = db_query("SELECT * FROM {plugin_autochangestatus} WHERE changestatus_id=".$edit_id);
     $change_datas = db_fetch_array($change_query);
 }
 

--- a/AutoChangeStatus/pages/changestatus.php
+++ b/AutoChangeStatus/pages/changestatus.php
@@ -21,21 +21,32 @@
 
 auth_reauthenticate();
 access_ensure_global_level(config_get('manage_plugin_threshold'));
-html_page_top(plugin_lang_get('title'));
+
+if ( gpc_get('submitDelete',false)) {
+    form_security_validate( 'plugin_AutoChangeStatus_changestatus_edit' );
+    helper_ensure_confirmed( sprintf( plugin_lang_get( 'ensure_delete' ), $t_repo->name ), plugin_lang_get( 'delete_changestatus' ) );
+    $query = "DELETE FROM ".db_get_table('plugin_autochangestatus')." WHERE changestatus_id=".db_param();
+    db_query_bound($query,array(gpc_get_int('changestatus_id')));
+    print_successful_redirect( plugin_page( 'config', true ) );
+    form_security_purge( 'plugin_AutoChangeStatus_changestatus_edit' );
+}
+
+layout_page_header(plugin_lang_get('title'));
+layout_page_begin();
 print_manage_menu();
 
 
 #Gestion de la soumission du formulaire (Création )
 if ( gpc_get('submitCreate',false)) {
-
-    $query = "INSERT INTO mantis_autochange_status
-        (`project_id`,`from_status`,`to_status`,`status_days`,`reminder`,`reminder_message`,`reminder_days`,`active`)
-        VALUES ( ".db_param().",".db_param().",".db_param().",".db_param().",".db_param().",".db_param().",".db_param().",".db_param().")";
+    form_security_validate( 'plugin_AutoChangeStatus_changestatus_edit' );
+    $query = "INSERT INTO ".db_get_table('plugin_autochangestatus')."
+        (`project_id`,`from_status`,`to_status`,`status_days`,`reminder`,`reminder_message`,`reminder_message_private`,`reminder_days`,`active`)
+        VALUES ( ".db_param().",".db_param().",".db_param().",".db_param().",".db_param().",".db_param().",".db_param().",".db_param().",".db_param().")";
 
     db_query_bound($query,
         array(gpc_get_int('project_id'), gpc_get_int('from_status'), gpc_get_int('to_status'),
         gpc_get_int('status_days'), gpc_get_int('reminder'),
-        gpc_get_string('reminder_message'),gpc_get_int('reminder_days'), gpc_get_int('active'))
+        gpc_get_string('reminder_message'),gpc_get_string('reminder_message_private'),gpc_get_int('reminder_days'), gpc_get_int('active'))
     );
 
     print_successful_redirect( plugin_page( 'config', true ) );
@@ -44,24 +55,23 @@ if ( gpc_get('submitCreate',false)) {
 
 #Gestion de la soumission du formulaire (Mise à jour )
 if ( gpc_get('submitEdit',false)) {
-
-    $query = "UPDATE mantis_autochange_status "
-        . "SET `project_id` =".db_param().",`from_status`=".db_param().",`to_status`=".db_param().",`status_days`=".db_param().",`reminder`=".db_param().",`reminder_message`=".db_param().",`reminder_days`=".db_param().",`active`=".db_param().""
+    form_security_validate( 'plugin_AutoChangeStatus_changestatus_edit' );
+    $query = "UPDATE ".db_get_table('plugin_autochangestatus')." "
+        . "SET `project_id` =".db_param().",`from_status`=".db_param().",`to_status`=".db_param().",`status_days`=".db_param().",`reminder`=".db_param().",`reminder_message`=".db_param().",`reminder_message_private`=".db_param().",`reminder_days`=".db_param().",`active`=".db_param().""
         ." WHERE changestatus_id=".db_param();
 
     db_query_bound($query,
         array(gpc_get_int('project_id'), gpc_get_int('from_status'), gpc_get_int('to_status'),
         gpc_get_int('status_days'), gpc_get_int('reminder'),
-        gpc_get_string('reminder_message'),gpc_get_int('reminder_days'), gpc_get_int('active'),gpc_get_int('changestatus_id'))
+        gpc_get_string('reminder_message'),gpc_get_string('reminder_message_private'),gpc_get_int('reminder_days'), gpc_get_int('active'),gpc_get_int('changestatus_id'))
     );
 
     print_successful_redirect( plugin_page( 'config', true ) );
-
 }
 
 #Mise à jour récupération des données
 if ( $edit_id = gpc_get_int('changestatus_id' , false) ) {
-    $change_query = db_query("SELECT * FROM mantis_autochange_status WHERE changestatus_id=".$edit_id);
+    $change_query = db_query("SELECT * FROM ".db_get_table('plugin_autochangestatus')." WHERE changestatus_id=".$edit_id);
     $change_datas = db_fetch_array($change_query);
 }
 
@@ -71,76 +81,123 @@ $function = 'print_status_option_list_plugin';
 
 $t_projects = project_cache_all();
 ?>
-<h2><?php echo plugin_lang_get('create_new_change_description'); ?></h2>
-<form action="<?php echo plugin_page('changestatus') ?>" method="post">
-    <table>
-        <tr <?php echo helper_alternate_class() ?>>
-            <td class="category"><?php echo plugin_lang_get('project'); ?></td>
-            <td>
-                <select name="project_id" >
-                    <option value="0"><?php echo plugin_lang_get('all_projects');?></option>
-                    <?php foreach ($t_projects as $project): ?>
-                    <option value="<?php echo $project['id']; ?>" <?php if ( $project['id'] == $change_datas['project_id'] ):?> selected="selected" <?php endif; ?>>
-                        <?php echo $project['name']; ?>
-                    </option>
-                    <?php endforeach; ?>
-                </select>
-            </td>
-        </tr>
-        <tr <?php echo helper_alternate_class() ?>>
-            <td class="category"><?php echo plugin_lang_get('from_status'); ?></td>
-            <td>
+<div class="col-md-12 col-xs-12">
+    <div class="space-10"></div>
+    <div class="form-container">
+        <form action="<?php echo plugin_page('changestatus') ?>" method="post">
+            <?php echo form_security_field( 'plugin_AutoChangeStatus_changestatus_edit' ) ?>
 
-                <?php echo $function("from_status" , $change_datas['from_status']); ?>
-            </td>
-        </tr>
-        <tr <?php echo helper_alternate_class() ?>>
-            <td class="category"><?php echo plugin_lang_get('to_status'); ?></td>
-            <td>
-                <?php echo $function("to_status",$change_datas['to_status']); ?>
-            </td>
-        </tr>
-        <tr <?php echo helper_alternate_class() ?>>
-            <td class="category"><?php echo plugin_lang_get('status_days'); ?></td>
-            <td>
-                <input type="text" name="status_days" size="3" maxlength="3" value="<?php echo $change_datas['status_days'];?>"/>
-            </td>
-        </tr>
-        <tr <?php echo helper_alternate_class() ?>>
-            <td class="category"><?php echo plugin_lang_get('reminder'); ?></td>
-            <td>
-                <select name="reminder" >
-                    <option value="1"<?php if ( 1 == $change_datas['reminder'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('yes'); ?></option>
-                    <option value="0"<?php if ( 0 == $change_datas['reminder'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('no'); ?></option>
-                </select>
-            </td>
-        </tr>
-        <tr <?php echo helper_alternate_class() ?>>
-            <td class="category"><?php echo plugin_lang_get('reminder_message'); ?></td>
-            <td>
-                <textarea name="reminder_message" cols="50" rows="5"><?php echo isset($change_datas['reminder_message']) ? $change_datas['reminder_message']: plugin_lang_get('before_change_status_message');?></textarea>
-            </td>
-        </tr>
-        <tr <?php echo helper_alternate_class() ?>>
-            <td class="category"><?php echo plugin_lang_get('reminder_days'); ?></td>
-            <td>
-                <input type="text" name="reminder_days" size="3" maxlength="3" value="<?php echo $change_datas['reminder_days'];?>"/>
-            </td>
-        </tr>
-        <tr <?php echo helper_alternate_class() ?>>
-            <td class="category"><?php echo plugin_lang_get('active'); ?></td>
-            <td>
-                <select name="active" >
-                    <option value="1" <?php if ( 1 == $change_datas['active'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('yes'); ?></option>
-                    <option value="0" <?php if ( 0 == $change_datas['active'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('no'); ?></option>
-                </select>
-            </td>
-        </tr>
-        <tr <?php echo helper_alternate_class() ?>>
-            <td class="center" colspan="2">
-                <?php if (isset($edit_id) ) : ?><input type="hidden" name="changestatus_id" value="<?php echo $edit_id;?>" /><?php endif; ?>
-                <input type="submit" name="<?php if (isset($edit_id) && $edit_id != 0 ) : ?>submitEdit<?php else: ?>submitCreate<?php endif; ?>" value="<?php echo plugin_lang_get("create_change") ?>"/>
-            </td>
-        </tr>
-    </table>
-</form>
+            <div class="widget-box widget-color-blue2">
+                <div class="widget-header widget-header-small">
+                    <h4 class="widget-title lighter">
+                        <?php echo plugin_lang_get('create_new_change_description') ?>
+                    </h4>
+                </div>
+                <div class="widget-body">
+                    <div class="widget-main no-padding">
+                        <div class="table-responsive">
+                            <table class="table table-bordered table-condensed table-striped">
+                                <tr>
+                                    <th class="category"><?php echo plugin_lang_get('project'); ?></th>
+                                    <td>
+                                        <select name="project_id" >
+                                            <option value="0"><?php echo plugin_lang_get('all_projects');?></option>
+                                            <?php foreach ($t_projects as $project): ?>
+                                            <option value="<?php echo $project['id']; ?>" <?php if ( $project['id'] == $change_datas['project_id'] ):?> selected="selected" <?php endif; ?>>
+                                                <?php echo $project['name']; ?>
+                                            </option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th class="category"><?php echo plugin_lang_get('from_status'); ?></th>
+                                    <td>
+                                        <?php echo $function("from_status" , $change_datas['from_status']); ?>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th class="category"><?php echo plugin_lang_get('to_status'); ?></th>
+                                    <td>
+                                        <?php echo $function("to_status",$change_datas['to_status']); ?>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th class="category">
+                                        <?php echo plugin_lang_get('status_days'); ?>
+                                        <br>
+                                        <span class="small"><?php echo plugin_lang_get('status_days_description'); ?></span>
+                                    </th>
+                                    <td>
+                                        <input type="text" class="center" name="status_days" size="3" maxlength="3" value="<?php echo $change_datas['status_days'];?>"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th class="category"><?php echo plugin_lang_get('reminder'); ?></th>
+                                    <td>
+                                        <select name="reminder" >
+                                            <option value="1"<?php if ( 1 == $change_datas['reminder'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('yes'); ?></option>
+                                            <option value="0"<?php if ( 0 == $change_datas['reminder'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('no'); ?></option>
+                                        </select>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th class="category"><?php echo plugin_lang_get('reminder_message'); ?></th>
+                                    <td>
+                                        <textarea name="reminder_message" cols="60" rows="10"><?php echo isset($change_datas['reminder_message']) ? $change_datas['reminder_message']: plugin_lang_get('before_change_status_message');?></textarea>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th class="category"><?php echo plugin_lang_get('reminder_message_private'); ?></th>
+                                    <td>
+                                        <label for="reminder_message_private_0">
+                                            <input type="radio" class="ace" name="reminder_message_private" id="reminder_message_private_0" value="0" <?php echo( ON != $change_datas['reminder_message_private'] ) ? 'checked="checked" ' : ''?>/>
+                                            <span class="lbl padding-6"><?php echo lang_get('public'); ?></span>
+                                        </label>
+                                        &nbsp;&nbsp;&nbsp;&nbsp;
+                                        <label for="reminder_message_private_1">
+                                            <input type="radio" class="ace" name="reminder_message_private" id="reminder_message_private_1" value="1" <?php echo( ON == $change_datas['reminder_message_private'] ) ? 'checked="checked" ' : ''?>/>
+                                            <span class="lbl padding-6"><?php echo lang_get('private'); ?></span>
+                                        </label>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th class="category">
+                                        <?php echo plugin_lang_get('reminder_days'); ?>
+                                        <br>
+                                        <span class="small"><?php echo plugin_lang_get('reminder_days_description'); ?></span>
+                                    </th>
+                                    <td>
+                                        <input type="text" class="center" name="reminder_days" size="3" maxlength="3" value="<?php echo $change_datas['reminder_days'];?>"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th class="category"><?php echo plugin_lang_get('active'); ?></th>
+                                    <td>
+                                        <select name="active" >
+                                            <option value="1" <?php if ( 1 == $change_datas['active'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('yes'); ?></option>
+                                            <option value="0" <?php if ( 0 == $change_datas['active'] ):?> selected="selected" <?php endif; ?>><?php echo plugin_lang_get('no'); ?></option>
+                                        </select>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="widget-toolbox padding-8 clearfix">
+                        <?php if (isset($edit_id) && $edit_id != 0): ?>
+                            <input type="hidden" name="changestatus_id" value="<?php echo $edit_id;?>" />
+                            <input type="submit" class="btn btn-primary btn-white btn-round" name="submitEdit" value="<?php echo plugin_lang_get( 'change' )?>" />
+                            <input type="submit" class="btn btn-danger btn-white btn-round" name="submitDelete" value="<?php echo plugin_lang_get( 'delete' )?>" />
+                        <?php else: ?>
+                            <input type="submit" class="btn btn-primary btn-white btn-round" name="submitCreate" value="<?php echo plugin_lang_get( 'create' )?>" />
+                        <?php endif; ?>
+                        <a class="btn btn-default btn-white btn-round" href="<?php echo plugin_page('config') ?>"><?php echo plugin_lang_get('back') ?></a>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php
+layout_page_end();

--- a/AutoChangeStatus/pages/changestatus.php
+++ b/AutoChangeStatus/pages/changestatus.php
@@ -46,7 +46,7 @@ if ( gpc_get('submitCreate',false)) {
     db_query_bound($query,
         array(gpc_get_int('project_id'), gpc_get_int('from_status'), gpc_get_int('to_status'),
         gpc_get_int('status_days'), gpc_get_int('reminder'),
-        gpc_get_string('reminder_message'),gpc_get_string('reminder_message_private'),gpc_get_int('reminder_days'), gpc_get_int('active'))
+        gpc_get_string('reminder_message'),gpc_get_int('reminder_message_private'),gpc_get_int('reminder_days'), gpc_get_int('active'))
     );
 
     print_successful_redirect( plugin_page( 'config', true ) );
@@ -63,7 +63,7 @@ if ( gpc_get('submitEdit',false)) {
     db_query_bound($query,
         array(gpc_get_int('project_id'), gpc_get_int('from_status'), gpc_get_int('to_status'),
         gpc_get_int('status_days'), gpc_get_int('reminder'),
-        gpc_get_string('reminder_message'),gpc_get_string('reminder_message_private'),gpc_get_int('reminder_days'), gpc_get_int('active'),gpc_get_int('changestatus_id'))
+        gpc_get_string('reminder_message'),gpc_get_int('reminder_message_private'),gpc_get_int('reminder_days'), gpc_get_int('active'),gpc_get_int('changestatus_id'))
     );
 
     print_successful_redirect( plugin_page( 'config', true ) );
@@ -150,13 +150,13 @@ $t_projects = project_cache_all();
                                 <tr>
                                     <th class="category"><?php echo plugin_lang_get('reminder_message_private'); ?></th>
                                     <td>
-                                        <label for="reminder_message_private_0">
-                                            <input type="radio" class="ace" name="reminder_message_private" id="reminder_message_private_0" value="0" <?php echo( ON != $change_datas['reminder_message_private'] ) ? 'checked="checked" ' : ''?>/>
+                                        <label for="reminder_message_private_off">
+                                            <input type="radio" class="ace" name="reminder_message_private" id="reminder_message_private_off" value="<?php echo OFF; ?>" <?php echo( ON != $change_datas['reminder_message_private'] ) ? 'checked="checked" ' : ''?>/>
                                             <span class="lbl padding-6"><?php echo lang_get('public'); ?></span>
                                         </label>
                                         &nbsp;&nbsp;&nbsp;&nbsp;
-                                        <label for="reminder_message_private_1">
-                                            <input type="radio" class="ace" name="reminder_message_private" id="reminder_message_private_1" value="1" <?php echo( ON == $change_datas['reminder_message_private'] ) ? 'checked="checked" ' : ''?>/>
+                                        <label for="reminder_message_private_on">
+                                            <input type="radio" class="ace" name="reminder_message_private" id="reminder_message_private_on" value="<?php echo ON; ?>" <?php echo( ON == $change_datas['reminder_message_private'] ) ? 'checked="checked" ' : ''?>/>
                                             <span class="lbl padding-6"><?php echo lang_get('private'); ?></span>
                                         </label>
                                     </td>

--- a/AutoChangeStatus/pages/config.php
+++ b/AutoChangeStatus/pages/config.php
@@ -27,16 +27,14 @@ layout_page_begin();
 
 print_manage_menu();
 
-$t_user_table = db_get_table('user');
-$query        = "SELECT id,username
-        FROM $t_user_table
+$query = "SELECT id,username
+        FROM {user}
         ORDER BY username ASC";
-
 $t_users = db_query($query);
 
-#$t_changes_table  = db_get_table('mantis_autochange_status');
-$query_changes    = "SELECT p.name AS project_name, pacs.* FROM ".db_get_table('plugin_autochangestatus')." pacs
-    LEFT JOIN ".db_get_table('project')." p ON p.id = pacs.project_id";
+$query_changes    = "SELECT p.name AS project_name, pacs.*
+    FROM {plugin_autochangestatus} pacs
+    LEFT JOIN {project} p ON p.id = pacs.project_id";
 $t_changes        = db_query($query_changes);
 $t_changes_number = db_num_rows($t_changes);
 

--- a/AutoChangeStatus/pages/config.php
+++ b/AutoChangeStatus/pages/config.php
@@ -40,6 +40,7 @@ $t_changes_number = db_num_rows($t_changes);
 
 #Nom des statuts avec les traductions
 $t_status_names = MantisEnum::getAssocArrayIndexedByValues( lang_get( 'status_enum_string' ) );
+require_once(dirname(__FILE__).'/functions.php');
 
 ?>
 
@@ -132,7 +133,7 @@ $t_status_names = MantisEnum::getAssocArrayIndexedByValues( lang_get( 'status_en
                                                 <td><?php echo htmlentities($t_status_names[$change['to_status']]); ?></td>
                                                 <td class="center"><?php echo $change['status_days']; ?></td>
                                                 <td class="center"><?php echo ($change['reminder'] == 1 ) ? plugin_lang_get('yes') : plugin_lang_get('no'); ?></td>
-                                                <td><?php echo nl2br(htmlentities($change['reminder_message'])); ?></td>
+                                                <td><?php echo nl2br(htmlentities(reminder_message_process( $change['reminder_message'], $change ))); ?></td>
                                                 <td class="center"><?php echo ($change['reminder_message_private'] == 1 ) ? plugin_lang_get('yes') : plugin_lang_get('no'); ?></td>
                                                 <td class="center"><?php echo $change['reminder_days']; ?></td>
                                                 <td class="center"><?php echo ($change['active'] == 1 ) ? plugin_lang_get('yes') : plugin_lang_get('no'); ?></td>

--- a/AutoChangeStatus/pages/config.php
+++ b/AutoChangeStatus/pages/config.php
@@ -22,11 +22,12 @@
 auth_reauthenticate();
 access_ensure_global_level(config_get('manage_plugin_threshold'));
 
-html_page_top(plugin_lang_get('title'));
+layout_page_header(plugin_lang_get('title'));
+layout_page_begin();
 
 print_manage_menu();
 
-$t_user_table = db_get_table('mantis_user_table');
+$t_user_table = db_get_table('user');
 $query        = "SELECT id,username
         FROM $t_user_table
         ORDER BY username ASC";
@@ -34,7 +35,8 @@ $query        = "SELECT id,username
 $t_users = db_query($query);
 
 #$t_changes_table  = db_get_table('mantis_autochange_status');
-$query_changes    = "SELECT * FROM mantis_autochange_status";
+$query_changes    = "SELECT p.name AS project_name, pacs.* FROM ".db_get_table('plugin_autochangestatus')." pacs
+    LEFT JOIN ".db_get_table('project')." p ON p.id = pacs.project_id";
 $t_changes        = db_query($query_changes);
 $t_changes_number = db_num_rows($t_changes);
 
@@ -42,63 +44,119 @@ $t_changes_number = db_num_rows($t_changes);
 $t_status_names = MantisEnum::getAssocArrayIndexedByValues( lang_get( 'status_enum_string' ) );
 
 ?>
-<br />
-<h2><?php echo plugin_lang_get('plugin_config_general_description'); ?></h2>
-<p><?php echo plugin_lang_get('plugin_config_description'); ?></p>
-<form action="<?php echo plugin_page('config_edit') ?>" method="post">
-    <table>
-        <tr <?php echo helper_alternate_class() ?>>
-            <td class="category"><?php echo plugin_lang_get('change_status_user'); ?></td>
-            <td>
-                <select name="change_status_user">
-                    <option value="0"><?php echo plugin_lang_get('select_user'); ?></option>
-                    <?php while ($user             = db_fetch_array($t_users)) : ?>
-                        <option value="<?php echo $user['id']; ?>" <?php if (plugin_config_get('change_status_user')== $user['id']):
-                            ?> selected="selected"<?php endif; ?> >
-                        <?php echo $user['username']; ?>
-                        </option>
-                    <?php endwhile; ?>
-                </select>
-            </td>
-        </tr>
-        <tr <?php echo helper_alternate_class() ?>>
-            <td class="center" colspan="2"><input type="submit" value="<?php echo plugin_lang_get("config_action_update") ?>"/></td>
-        </tr>
-    </table>
-</form>
 
-<h2><?php echo plugin_lang_get('plugin_changes_list'); ?></h2>
-<table class="width100" cellspacing="1">
-    <tr class="row-category" >
-        <td><?php echo plugin_lang_get('project'); ?></td>
-        <td><?php echo plugin_lang_get('from_status'); ?></td>
-        <td><?php echo plugin_lang_get('to_status'); ?></td>
-        <td><?php echo plugin_lang_get('status_days'); ?></td>
-        <td><?php echo plugin_lang_get('reminder'); ?></td>
-        <td><?php echo plugin_lang_get('reminder_message'); ?></td>
-        <td><?php echo plugin_lang_get('reminder_days'); ?></td>
-        <td><?php echo plugin_lang_get('active'); ?></td>
-        <td><?php echo plugin_lang_get('edit'); ?></td>
-    </tr>
-    <?php if ($t_changes_number > 0) : ?>
-    <?php while ($change = db_fetch_array($t_changes)) : ?>
-            <tr  <?php echo helper_alternate_class() ?>>
-                <td><?php echo $change['project_id']; ?></td>
-                <td><?php echo $t_status_names[$change['from_status']]; ?></td>
-                <td><?php echo $t_status_names[$change['to_status']]; ?></td>
-                <td><?php echo $change['status_days']; ?></td>
-                <td><?php echo ($change['reminder'] == 1 ) ? plugin_lang_get('yes') : plugin_lang_get('no'); ?></td>
-                <td><?php echo $change['reminder_message']; ?></td>
-                <td><?php echo $change['reminder_days']; ?></td>
-                <td><?php echo ($change['active'] == 1 ) ? plugin_lang_get('yes') : plugin_lang_get('no'); ?></td>
-                <td><a href="<?php echo plugin_page('changestatus');?>&changestatus_id=<?php echo $change['changestatus_id']; ?>"><?php echo plugin_lang_get('edit'); ?></a>
-            </tr>
-        <?php endwhile; ?>
-<?php else: ?>
-        <tr class="row-1">
-            <td colspan="9" style="text-align:center;"><?php echo plugin_lang_get('no_update_changes_created'); ?></td>
-        </tr>
-<?php endif; ?>
-</table>
+<div class="col-md-12 col-xs-12">
+    <div class="space-10"></div>
+    <div class="form-container">
+        <form action="<?php echo plugin_page( 'config_edit' )?>" method="post">
+            <?php echo form_security_field( 'plugin_AutoChangeStatus_config_edit' ) ?>
 
-<p><a href="<?php echo plugin_page('changestatus');?>"><?php echo plugin_lang_get('create_new_status_update');?></a></p>
+            <div class="widget-box widget-color-blue2">
+                <div class="widget-header widget-header-small">
+                    <h4 class="widget-title lighter">
+                        <?php echo plugin_lang_get('plugin_config_general_description') ?>
+                    </h4>
+                </div>
+                <div class="widget-body">
+                    <div class="widget-main no-padding">
+                        <div class="table-responsive">
+                            <table class="table table-bordered table-condensed table-striped">
+                                <tr>
+                                    <th class="category">
+                                        <?php echo plugin_lang_get('change_status_user'); ?>
+                                    </th>
+                                    <td>
+                                        <select name="change_status_user">
+                                            <option value="0"><?php echo plugin_lang_get('select_user'); ?></option>
+                                            <?php while ($user = db_fetch_array($t_users)) : ?>
+                                                <option value="<?php echo $user['id']; ?>" <?php if (plugin_config_get('change_status_user')== $user['id']):
+                                                    ?> selected="selected"<?php endif; ?> >
+                                                <?php echo $user['username']; ?>
+                                                </option>
+                                            <?php endwhile; ?>
+                                        </select>
+                                        <br>
+                                        <span class="small"><?php echo plugin_lang_get('plugin_config_description'); ?></span>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="widget-toolbox padding-8 clearfix">
+                        <input type="submit" class="btn btn-primary btn-white btn-round" value="<?php echo lang_get( 'change_configuration' )?>" />
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+
+    <div class="space-10"></div>
+
+    <div class="form-container">
+        <form id="formatting-config-form" action="<?php echo plugin_page( 'config_edit' )?>" method="post">
+            <?php echo form_security_field( 'plugin_AutoChangeStatus_config_edit' ) ?>
+
+            <div class="widget-box widget-color-blue2">
+                <div class="widget-header widget-header-small">
+                    <h4 class="widget-title lighter">
+                        <?php echo plugin_lang_get('plugin_changes_list'); ?>
+                    </h4>
+                </div>
+                <div class="widget-body">
+                    <div class="widget-main no-padding">
+                        <div class="table-responsive">
+                            <table class="table table-bordered table-condensed table-striped">
+                                <thead>
+                                    <tr>
+                                        <th class="column-edit"> &nbsp; </th>
+                                        <th><?php echo plugin_lang_get('project'); ?></th>
+                                        <th><?php echo plugin_lang_get('from_status'); ?></th>
+                                        <th><?php echo plugin_lang_get('to_status'); ?></th>
+                                        <th><?php echo plugin_lang_get('status_days'); ?></th>
+                                        <th><?php echo plugin_lang_get('reminder'); ?></th>
+                                        <th><?php echo plugin_lang_get('reminder_message'); ?></th>
+                                        <th><?php echo plugin_lang_get('reminder_message_private_short'); ?></th>
+                                        <th><?php echo plugin_lang_get('reminder_days'); ?></th>
+                                        <th><?php echo plugin_lang_get('active'); ?></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php if ($t_changes_number > 0) : ?>
+                                        <?php while ($change = db_fetch_array($t_changes)) : ?>
+                                            <tr>
+                                                <td class="column-edit center">
+                                                    <a href="<?php echo plugin_page('changestatus');?>&changestatus_id=<?php echo $change['changestatus_id']; ?>">
+                                                        <i class="fa fa-pencil bigger-130 padding-2 grey" title="<?php echo plugin_lang_get('edit'); ?>"></i>
+                                                    </a>
+                                                </td>
+                                                <td><?php echo htmlentities($change['project_name']); ?></td>
+                                                <td><?php echo htmlentities($t_status_names[$change['from_status']]); ?></td>
+                                                <td><?php echo htmlentities($t_status_names[$change['to_status']]); ?></td>
+                                                <td class="center"><?php echo $change['status_days']; ?></td>
+                                                <td class="center"><?php echo ($change['reminder'] == 1 ) ? plugin_lang_get('yes') : plugin_lang_get('no'); ?></td>
+                                                <td><?php echo nl2br(htmlentities($change['reminder_message'])); ?></td>
+                                                <td class="center"><?php echo ($change['reminder_message_private'] == 1 ) ? plugin_lang_get('yes') : plugin_lang_get('no'); ?></td>
+                                                <td class="center"><?php echo $change['reminder_days']; ?></td>
+                                                <td class="center"><?php echo ($change['active'] == 1 ) ? plugin_lang_get('yes') : plugin_lang_get('no'); ?></td>
+                                            </tr>
+                                        <?php endwhile; ?>
+                                    <?php else: ?>
+                                        <tr>
+                                            <td colspan="9" class="center"><?php echo plugin_lang_get('no_update_changes_created'); ?></td>
+                                        </tr>
+                                    <?php endif; ?>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="widget-toolbox padding-8 clearfix">
+                        <a href="<?php echo plugin_page('changestatus');?>" class="btn btn-primary btn-white btn-round"><?php echo plugin_lang_get("create_new_status_update") ?></a>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php
+layout_page_end();

--- a/AutoChangeStatus/pages/config_edit.php
+++ b/AutoChangeStatus/pages/config_edit.php
@@ -19,6 +19,8 @@
 #    2015-2016
 #  http://www.h-hennes.fr/blog/
 
+form_security_validate( 'plugin_AutoChangeStatus_config_edit' );
+
 auth_reauthenticate( );
 access_ensure_global_level( config_get( 'manage_plugin_threshold' ) );
 

--- a/AutoChangeStatus/pages/cron.php
+++ b/AutoChangeStatus/pages/cron.php
@@ -18,8 +18,6 @@
 #  © Hennes Hervé <contact@h-hennes.fr>
 #    2015-2016
 #  http://www.h-hennes.fr/blog/
-
-require_once( dirname(__FILE__) . '/../../../core.php' );
 require_once(dirname(__FILE__).'/functions.php');
 
 #En cron on push le nom du module
@@ -145,4 +143,3 @@ while ($change = db_fetch_array($change_status)) {
         }
      }
 }
-

--- a/AutoChangeStatus/pages/cron.php
+++ b/AutoChangeStatus/pages/cron.php
@@ -32,27 +32,27 @@ $t_status_names = MantisEnum::getAssocArrayIndexedByValues( lang_get( 'status_en
 
 #Requête pour récupérer la date de modification du statut avec le nombre de jours correspondants
     $sql_status = "SELECT h.* , FROM_UNIXTIME(date_modified, '%Y-%m-%d') AS date_status_modified
-             FROM mantis_bug_table b
-             LEFT JOIN mantis_bug_history_table h ON ( b.id = h.bug_id AND field_name='status' AND new_value=".db_param()." )
+             FROM {bug} b
+             LEFT JOIN {bug_history} h ON ( b.id = h.bug_id AND field_name='status' AND new_value=".db_param()." )
              WHERE b.status = ".db_param()." AND b.project_id = ".db_param()."
              AND CURDATE() = DATE_ADD(FROM_UNIXTIME(date_modified, '%Y-%m-%d'), INTERVAL ".db_param()." DAY)";
-    			 
-	#@ToDO : Essayer de grouper les requêtes		 
+
+	#@ToDO : Essayer de grouper les requêtes
 	$sql_status_no_project =  "SELECT h.* , FROM_UNIXTIME(date_modified, '%Y-%m-%d') AS date_status_modified
-             FROM mantis_bug_table b
-             LEFT JOIN mantis_bug_history_table h ON ( b.id = h.bug_id AND field_name='status' AND new_value=".db_param()." )
+             FROM {bug} b
+             LEFT JOIN {bug_history} h ON ( b.id = h.bug_id AND field_name='status' AND new_value=".db_param()." )
              WHERE b.status = ".db_param()."
-             AND CURDATE() = DATE_ADD(FROM_UNIXTIME(date_modified, '%Y-%m-%d'), INTERVAL ".db_param()." DAY)";		 
+             AND CURDATE() = DATE_ADD(FROM_UNIXTIME(date_modified, '%Y-%m-%d'), INTERVAL ".db_param()." DAY)";
 
 #Requête pour récupérer la date de la dernière note UTILISATEUR sur le bug
-    $sql_notes = "SELECT * FROM mantis_bugnote_table
+    $sql_notes = "SELECT * FROM {bugnote}
                   WHERE bug_id= ".db_param().
         " AND reporter_id <> ".plugin_config_get('change_status_user').
         " AND date_submitted > ".db_param();
 
 
 #Récupération des changements automatiques qui sont actifs
-$change_status = db_query("SELECT * FROM mantis_autochange_status WHERE active=1");
+$change_status = db_query("SELECT * FROM {plugin_autochangestatus} WHERE active=1");
 
 #Boucle de traitement
 while ($change = db_fetch_array($change_status)) {

--- a/AutoChangeStatus/pages/cron.php
+++ b/AutoChangeStatus/pages/cron.php
@@ -17,19 +17,19 @@
 #  Autochange status Plugin for Mantis BugTracker :
 #  © Hennes Hervé <contact@h-hennes.fr>
 #    2015-2016
-#  http://www.h-hennes.fr/blog/  
+#  http://www.h-hennes.fr/blog/
 
 require_once( dirname(__FILE__) . '/../../../core.php' );
+require_once(dirname(__FILE__).'/functions.php');
 
 #En cron on push le nom du module
 plugin_push_current('AutoChangeStatus');
 
 #Utilisateur par défaut
 $g_cron_current_user_id = plugin_config_get('change_status_user');
-
+$g_cache_current_user_id = $g_cron_current_user_id;
 #Nom des statuts avec les traductions
 $t_status_names = MantisEnum::getAssocArrayIndexedByValues( lang_get( 'status_enum_string' ) );
-
 #Requête pour récupérer la date de modification du statut avec le nombre de jours correspondants
     $sql_status = "SELECT h.* , FROM_UNIXTIME(date_modified, '%Y-%m-%d') AS date_status_modified
              FROM {bug} b
@@ -47,13 +47,11 @@ $t_status_names = MantisEnum::getAssocArrayIndexedByValues( lang_get( 'status_en
 #Requête pour récupérer la date de la dernière note UTILISATEUR sur le bug
     $sql_notes = "SELECT * FROM {bugnote}
                   WHERE bug_id= ".db_param().
-        " AND reporter_id <> ".plugin_config_get('change_status_user').
+        " AND reporter_id <> ".db_param().
         " AND date_submitted > ".db_param();
-
 
 #Récupération des changements automatiques qui sont actifs
 $change_status = db_query("SELECT * FROM {plugin_autochangestatus} WHERE active=1");
-
 #Boucle de traitement
 while ($change = db_fetch_array($change_status)) {
 
@@ -61,7 +59,6 @@ while ($change = db_fetch_array($change_status)) {
 # 1ère étape : Ajout des notes de rappel ( si actif )
 ###
     if ($change['reminder'] == 1) {
-
         #Récupération des bugs éligibles à l'ajout d'une note de rappel
 		if ( $change['project_id'] != 0 ) {
 			$t_bug_notes_pool = db_query_bound($sql_status,
@@ -76,14 +73,33 @@ while ($change = db_fetch_array($change_status)) {
 
             #On regarde si ces bugs ont été commenté dans la période
             $t_user_notes = db_query_bound($sql_notes,
-                array($t_bug['bug_id'], $t_bug['date_modified']));
+                array($t_bug['bug_id'], $g_cron_current_user_id, $t_bug['date_modified']));
 
             #Si pas de notes on en rajoute une
             if (db_num_rows($t_user_notes) < 1) {
-
-                $t_bugnote_text = sprintf(plugin_lang_get('before_change_status_message'),$t_status_names[$change['from_status']],$change['reminder_days'],$t_status_names[$change['to_status']],($change['status_days'] - $change['reminder_days']));
-                bugnote_add( $t_bug['bug_id'], $t_bugnote_text,'0:02', false, BUGNOTE,'', $g_cron_current_user_id);
-            
+                if($change['reminder_message'] === plugin_lang_get('before_change_status_message'))
+                {
+                    $t_bugnote_text = sprintf(
+                        plugin_lang_get('before_change_status_message'),
+                            $t_status_names[$change['from_status']],
+                            $change['reminder_days'],
+                            $t_status_names[$change['to_status']],
+                            ($change['status_days'] - $change['reminder_days'])
+                    );
+                }
+                else
+                {
+                    $t_bugnote_text = reminder_message_process($change['reminder_message'], $change);
+                }
+                bugnote_add(
+                    $t_bug['bug_id'],
+                    $t_bugnote_text,
+                    '',
+                    (ON == $change['reminder_message_private']),
+                    BUGNOTE,
+                    '',
+                    $g_cron_current_user_id
+                );
             }
         }
     }
@@ -91,7 +107,7 @@ while ($change = db_fetch_array($change_status)) {
 ####
 # 2ème étape : Changement automatique des statuts
 ###
-    
+
 	if ( $change['project_id'] != 0 ) {
         $t_bug_status_pool = db_query_bound($sql_status,
             array($change['from_status'], $change['from_status'], $change['project_id'],
@@ -105,14 +121,22 @@ while ($change = db_fetch_array($change_status)) {
 
             #On regarde si ces bugs ont été commenté dans la période
             $t_user_notes_status = db_query_bound($sql_notes,
-                array($t_bug_status['bug_id'], $t_bug_status['date_modif']));
+                array($t_bug_status['bug_id'], $g_cron_current_user_id, $t_bug_status['date_modif']));
 
             #Si pas de notes on en rajoute une
             if (db_num_rows($t_user_notes_status) < 1) {
 
                 #Rajout d'une note informative
-                $t_bugnote_text_status = sprintf(plugin_lang_get('change_status_message'),$change['status_days']);
-                bugnote_add( $t_bug_status['bug_id'], $t_bugnote_text_status,'0:02', false, BUGNOTE,'', $g_cron_current_user_id);
+                $t_bugnote_text_status = sprintf(plugin_lang_get('change_status_message'),$t_status_names[$change['to_status']],$change['status_days']);
+                bugnote_add(
+                    $t_bug_status['bug_id'],
+                    $t_bugnote_text_status,
+                    '',
+                    (ON == $change['reminder_message_private']),
+                    BUGNOTE,
+                    '',
+                    $g_cron_current_user_id
+                );
 
                 #Changement du status du bug
                 $t_bug_model = bug_get($t_bug_status['bug_id']);
@@ -120,4 +144,5 @@ while ($change = db_fetch_array($change_status)) {
                 $t_bug_model->update();
         }
      }
-}  
+}
+

--- a/AutoChangeStatus/pages/functions.php
+++ b/AutoChangeStatus/pages/functions.php
@@ -80,3 +80,31 @@ function get_status_option_list_plugin( $p_user_auth = 0, $p_current_value = 0, 
 
 	return $t_enum_list;
 }
+
+#Retourne le message avec les remplacements des macros en bonne et due forme
+function reminder_message_process( $p_message, $p_change = array() )
+{
+	global $t_status_names;
+	$status_names = $t_status_names;
+	$message = $p_message;
+	$replace = '';
+	if( empty($status_names) )
+	{
+		$status_names = MantisEnum::getAssocArrayIndexedByValues( lang_get( 'status_enum_string' ) );
+	}
+	foreach( $p_change as $key => $val )
+	{
+		$replace = $p_change[ $key ];
+		if( 'from_status' == $key || 'to_status' == $key )
+		{
+			$replace = $status_names[$replace];
+		}
+		elseif( 'status_days' == $key )
+		{
+			$replace = ($p_change['status_days'] - $p_change['reminder_days']);
+		}
+		$message = str_replace( '{'.$key.'}', $replace, $message );
+	}
+
+	return $message;
+}

--- a/AutoChangeStatus/pages/functions.php
+++ b/AutoChangeStatus/pages/functions.php
@@ -37,7 +37,7 @@ function print_status_option_list_plugin( $p_select_label, $p_current_value = 0,
                     #On ne veut pas afficher la valeur @0@
                     if ( $val == '@0@')
                         continue;
-               
+
 			echo '<option value="' . $key . '"';
 			check_selected( $key, $p_current_value,false );#fix 1.3.0
 			echo '>' . $val . '</option>';
@@ -55,7 +55,7 @@ function get_status_option_list_plugin( $p_user_auth = 0, $p_current_value = 0, 
 	$t_config_var_value = config_get( 'status_enum_string', null, null, $p_project_id );
 	$t_enum_workflow = config_get( 'status_enum_workflow', null, null, $p_project_id );
 
-	
+
 	$t_enum_values = MantisEnum::getValues( $t_config_var_value );
 	$t_enum_list = array();
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ This plugin will change automaticaly bug statuts to another after a configurable
 </p>
 
 <p>In order to process the change add a daily crontab on the folowing file </p>
-<pre>mantisdir/plugins/AutoChangeStatus/pages/cron.php </pre>
+<pre>wget http://yourwebsite.com/mantisdir/plugins/AutoChangeStatus/pages/cron.php </pre>
 
-Plugin for mantis bug tracker 1.3.x
+Plugin for mantis bug tracker 2.x
 
-A version for mantis bug tracker 1.2.x is avalaible on the branch 1.2.x
+A version for mantis bug tracker 1.3.x is available on the branch 1.3.x
+
+A version for mantis bug tracker 1.2.x is available on the branch 1.2.x

--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
 # mantisbt_autochangestatus
-This plugin will change automaticaly bug statuts to another after a configurable period
+This plugin will change automatically bug status to another after a configurable period.
 
 <p>Configuration :<br />
 <img src="http://www.h-hennes.fr/blog/wp-content/uploads/2015/08/changestatus.jpg" alt="Configuration" />
 </p>
 
-<p>You can choose wich user will change the status<br />The active change are listed below.</p>
+<p>You can choose which user will change the status<br />
+The active change are listed below.</p>
 
 <p>Add a new Change <br /> :
 <img src="http://www.h-hennes.fr/blog/wp-content/uploads/2015/08/add-status-change.jpg" alt="Status Change" />
 </p>
 
-<p>In order to process the change add a daily crontab on the folowing file </p>
-<pre>wget http://yourwebsite.com/mantisdir/plugins/AutoChangeStatus/pages/cron.php </pre>
+<p>In order to process the change, add a daily crontab on the following URL:</p>
+<pre>http://yourwebsite.com/plugin.php?page=AutoChangeStatus/cron</pre>
 
 Plugin for mantis bug tracker 2.x
 
-A version for mantis bug tracker 1.3.x is available on the branch 1.3.x
-
-A version for mantis bug tracker 1.2.x is available on the branch 1.2.x
+A version for mantis bug tracker 1.3.x and 1.2.x are available on their respective branches.


### PR DESCRIPTION
# Changelog

* Le plugin est maintenant compatible avec Mantis 2.x
* Il est désormais possible de supprimer une règle définie précédemment
* Les note de rappel peuvent être privée (se configure au niveau de la règle)
* Le message de rappel est pris en compte (dans la langue saisie uniquement)
* Les macros `{from_status}`, `{to_status}`, `{reminder_days}`, `{status_days}` sont disponibles pour le message de rappel.
* BUGFIX: L'historique d'un bug n'était pas modifié lors de l'ajout automatique d'une note de rappel